### PR TITLE
fix: add asymmetric signing hook options

### DIFF
--- a/libraries/go/webhook_test.go
+++ b/libraries/go/webhook_test.go
@@ -89,14 +89,14 @@ func TestWebhook(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-        {
-            name:        "partial signature is invalid",
-            testPayload: newTestPayload(time.Now()),
-            modifyPayload: func(tp *testPayload) {
-                tp.header.Set("webhook-signature", "v1,")
-            },
-            expectedErr: true,
-        },
+		{
+			name:        "partial signature is invalid",
+			testPayload: newTestPayload(time.Now()),
+			modifyPayload: func(tp *testPayload) {
+				tp.header.Set("webhook-signature", "v1,")
+			},
+			expectedErr: true,
+		},
 		{
 			name:        "old timestamp fails",
 			testPayload: newTestPayload(time.Now().Add(tolerance * -1)),

--- a/libraries/go/webhook_test.go
+++ b/libraries/go/webhook_test.go
@@ -89,14 +89,14 @@ func TestWebhook(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-		{
-			name:        "partial signature is invalid",
-			testPayload: newTestPayload(time.Now()),
-			modifyPayload: func(tp *testPayload) {
-				tp.header.Set("webhook-signature", "v1,")
-			},
-			expectedErr: true,
-		},
+        {
+            name:        "partial signature is invalid",
+            testPayload: newTestPayload(time.Now()),
+            modifyPayload: func(tp *testPayload) {
+                tp.header.Set("webhook-signature", "v1,")
+            },
+            expectedErr: true,
+        },
 		{
 			name:        "old timestamp fails",
 			testPayload: newTestPayload(time.Now().Add(tolerance * -1)),


### PR DESCRIPTION
An implementation of asymmetric signing. Introduces two initializers `NewAsymmetricVerificationHook` and `NewAsymmetricSigningHook` which accept a public key and private key respectively.  

There's also a new `signingMethod` field which will  allow us to distinguish between symmetric and asymmetric.

Other considerations:

1. Implement a separate `AsymmetricWebhook` struct which contains  public, private key, and options.
- Decoupled from existing implementation, can freely modify without affecting current code
- Don't have to take into account the symmetric case. 

2. Modify the existing `NewWebhook` constructor to accept additional variadic arguments or optional arguments which we can infer as  the public key / private key
- Knowledge is encoded into the position of the argument

For use in Supabase Auth this would be the rough change applied to [this crypto code section](https://github.com/supabase/auth/blob/master/internal/crypto/crypto.go#L54)

```
if strings.HasPrefix(secret, SymmetricSignaturePrefix) {
	trimmedSecret := strings.TrimPrefix(secret, SymmetricSignaturePrefix)
	wh, err := standardwebhooks.NewWebhook(trimmedSecret)
	if err != nil {
		return nil, err
	}
	signature, err := wh.Sign(msgID.String(), currentTime, inputPayload)
	if err != nil {
		return nil, err
	}
	signatureList = append(signatureList, signature)
	}  else if strings.HasPrefix(secret, AsymmetricSignaturePrefix) {
        trimmedSecret := strings.TrimPrefix(secret, AsymmetricSignaturePrefix)
        // v1a,whpk_..... whsk_
        privateKey := strings.split(":")[1]
        // find secret key
        trimmedPrivateKey := strings.TrimPrefix(privateKey, "whks_")
	wh, err := standardwebhooks.NewAsymmetricSigningWebhook(trimmedPrivateKey)
	if err != nil {
		return nil, err
	}
           
         }
 }
```

