### PR TITLE
feat: second pass, asymmetric signing

### DIFF
--- a/libraries/go/example_webhook_test.go
+++ b/libraries/go/example_webhook_test.go
@@ -1,6 +1,8 @@
 package standardwebhooks_test
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"fmt"
 	"log"
 	"net/http"
@@ -46,6 +48,65 @@ func Example_signatureFlow() {
 	err = wh.Verify([]byte(payload), header)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	fmt.Println("done")
+	// Output: done
+}
+func generateEd25519Keys() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	return ed25519.GenerateKey(rand.Reader)
+}
+
+func Example_asymmetricSignatureFlow() {
+	pubKey, privKey, err := generateEd25519Keys()
+	if err != nil {
+		log.Fatalf("failed to generate Ed25519 keys: %v", err)
+	}
+
+	// Convert the private key into the format expected by WebhookOptions
+	options := &standardwebhooks.WebhookOptions{
+		KeyObject: standardwebhooks.KeyObject{
+			KeyObjectType: standardwebhooks.PrivateKeyType,
+			Key:           privKey,
+		},
+	}
+
+	wh, err := standardwebhooks.NewWebhookWithOptions(standardwebhooks.ED25519, options)
+	if err != nil {
+		log.Fatalf("failed to create webhook with options: %v", err)
+	}
+
+	var (
+		ts      = time.Now()
+		id      = "1234567890"
+		payload = `{"type": "example.created", "timestamp":"2023-09-28T19:20:22+00:00", "data":{"str":"string","bool":true,"int":42}}`
+	)
+
+	signature, err := wh.Sign(id, ts, []byte(payload))
+	if err != nil {
+		log.Fatalf("failed to sign payload: %v", err)
+	}
+
+	// Generating the HTTP header carrier with base64 encoded signature
+	header := http.Header{}
+	header.Set(standardwebhooks.HeaderWebhookID, id)
+	header.Set(standardwebhooks.HeaderWebhookSignature, fmt.Sprintf("%s", signature))
+	header.Set(standardwebhooks.HeaderWebhookTimestamp, fmt.Sprint(ts.Unix()))
+
+	verifyOptions := &standardwebhooks.WebhookOptions{
+		KeyObject: standardwebhooks.KeyObject{
+			KeyObjectType: standardwebhooks.PublicKeyType,
+			Key:           pubKey,
+		},
+	}
+	verifyWh, err := standardwebhooks.NewWebhookWithOptions(standardwebhooks.ED25519, verifyOptions)
+	if err != nil {
+		log.Fatalf("failed to create verification webhook with options: %v", err)
+	}
+
+	err = verifyWh.Verify([]byte(payload), header)
+	if err != nil {
+		log.Fatalf("failed to verify payload: %v", err)
 	}
 
 	fmt.Println("done")

--- a/libraries/go/webhook.go
+++ b/libraries/go/webhook.go
@@ -137,10 +137,8 @@ func (wh *Webhook) verify(payload []byte, headers http.Header, enforceTolerance 
 			continue
 		}
 		version := sigParts[0]
-		if version != "v1" {
-			continue
-		}
 		signature := []byte(sigParts[1])
+
 		switch version {
 		case "v1":
 			if wh.method != HMAC {

--- a/libraries/go/webhook_test.go
+++ b/libraries/go/webhook_test.go
@@ -89,14 +89,14 @@ func TestWebhook(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-        {
-            name:        "partial signature is invalid",
-            testPayload: newTestPayload(time.Now()),
-            modifyPayload: func(tp *testPayload) {
-                tp.header.Set("webhook-signature", "v1,")
-            },
-            expectedErr: true,
-        },
+		{
+			name:        "partial signature is invalid",
+			testPayload: newTestPayload(time.Now()),
+			modifyPayload: func(tp *testPayload) {
+				tp.header.Set("webhook-signature", "v1,")
+			},
+			expectedErr: true,
+		},
 		{
 			name:        "old timestamp fails",
 			testPayload: newTestPayload(time.Now().Add(tolerance * -1)),


### PR DESCRIPTION
Supercedes [the first implementation](https://github.com/J0/standard-webhooks/pull/1)

We wil lcontinue to iterate on the first iteration here.